### PR TITLE
DM-29039: Alter pre-release version format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lsst-sqre/rubin-style-dictionary",
-  "version": "0.3.0-beta+2",
+  "version": "0.3.0-beta.2",
   "description": "A style dictionary that encodes design tokens from the Rubin Visual Identity.",
   "main": "dist/tokens.js",
   "files": [


### PR DESCRIPTION
The `0.3.0-beta+2` format wasn't being recognized as different `0.3.0-beta+1` by the packaging action. This PR modifies the release format to `0.3.0-beta.2` to see if that's correct.