### PR TITLE
DM-29251: Support for next-themes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,16 +5,18 @@ Change log
 0.3.0 (unreleased)
 ==================
 
-Added image assets from the Rubin Visual Identity, including imagotypes, favicons, watermarks, and partner logos.
+- Added image assets from the Rubin Visual Identity, including imagotypes, favicons, watermarks, and partner logos.
 The imagotypes in this distribution are additionally cropped so that the clearance corresponds to the desired "N" spacing.
 
-These files can be imported from the NPM package as regular static assets.
-Additionally, these assets are distributed in JSON files as Base 64-encoded strings.
+  These files can be imported from the NPM package as regular static assets.
+  Additionally, these assets are distributed in JSON files as Base 64-encoded strings.
 
-Development dependencies:
+- Support for theming with next-themes.
+
+- Development dependencies:
 
 - Updated lodash to 4.17.21
-- Updated style-dictionary to 3.0.0-rc.5
+- Updated style-dictionary to 3.0.0-rc.6
 
 0.2.1 (2021-02-17)
 ==================

--- a/build.js
+++ b/build.js
@@ -53,14 +53,16 @@ function variablesWithPrefix(prefix, properties, commentStyle) {
     .join('\n');
 }
 
-// Register css/dark custom format that uses a body.dark selector
-// for "dark" mode tokens.
+// Register css/dark custom format for "dark" theme tokens.
+// It supports two selectors:
+// - body.dark (a class selector) compatible with gatsby-plugin-dark-mode
+// - [data-theme='dark'] body (data attribute) compatible with next-themes
 styleDictionary.registerFormat({
   name: 'css/dark',
   formatter: function (dictionary) {
     return (
       fileHeader(this.options) +
-      'body.dark {\n' +
+      "body.dark, [data-theme='dark'] body {\n" +
       variablesWithPrefix('  --', dictionary.allProperties) +
       '\n}\n'
     );

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,6 +156,8 @@ rst_epilog = """
 .. _rubin-style-dictionary:
 .. _rubin-style-dictionary repository: https://github.com/lsst-sqre/rubin-style-dictionary
 .. _Visual Identity Manual: https://docushare.lsst.org/docushare/dsweb/Get/Document-37294/20210212%20Visual%20Identity%20Manual%20%e2%80%94V7.pdf
+.. _gatsby-plugin-dark-mode: https://www.gatsbyjs.com/plugins/gatsby-plugin-dark-mode/
+.. _next-themes: https://github.com/pacocoursey/next-themes
 
 .. Substitutions
 

--- a/docs/tokens.dark.css.rst
+++ b/docs/tokens.dark.css.rst
@@ -3,6 +3,11 @@ tokens.dark.css
 ###############
 
 This CSS file contains tokens, as CSS custom properties, corresponding only to the ``dark`` theme.
+The CSS selectors in this file support both Gatsby and Next.js theme patterns:
+
+- ``body.dark`` class selector for Gatsby gatsby-plugin-dark-mode_ apps.
+- ``[data-theme='dark'] body`` selector for Next.js and next-themes_\ -based apps.
+
 Since these CSS custom properties are scoped with the ``body.dark`` selector, and shadow the names of default or ``light`` themed tokens, these tokens become active when the ``dark`` class is applied to the body.
 See :doc:`tokens.css` for the tokens corresponding to the light theme and to unthemed tokens.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lsst-sqre/rubin-style-dictionary",
-  "version": "0.3.0-beta.3",
+  "version": "0.3.0-beta.4",
   "description": "A style dictionary that encodes design tokens from the Rubin Visual Identity.",
   "main": "dist/tokens.js",
   "files": [


### PR DESCRIPTION
The [next-themes](https://github.com/pacocoursey/next-themes) package applies theme information to a data-themes attribute. To support this, the ``css/dark`` format uses the `[data-theme='dark'] body` selector (in addition to the `body.dark` selector already used for Gatsby and gatsby-plugin-dark-mode sites.