### PR TITLE
DM-29251: Initial set of component design tokens for colours in squareone

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ The imagotypes in this distribution are additionally cropped so that the clearan
 
 - Support for theming with next-themes.
 
+- Initial design tokens from components originating in the Squareone application (https://github.com/lsst-sqre/rsp-squareone).
+
 - Development dependencies:
 
 - Updated lodash to 4.17.21

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lsst-sqre/rubin-style-dictionary",
-  "version": "0.3.0-beta.4",
+  "version": "0.3.0-beta.5",
   "description": "A style dictionary that encodes design tokens from the Rubin Visual Identity.",
   "main": "dist/tokens.js",
   "files": [

--- a/src/component/footer.yaml
+++ b/src/component/footer.yaml
@@ -1,0 +1,9 @@
+component:
+  # Page footer component
+  footer:
+    backgroundColor:
+      themed:
+        light:
+          value: '{color.primary.100.value}'
+        dark:
+          value: '{color.primary.700.value}'

--- a/src/component/header.yaml
+++ b/src/component/header.yaml
@@ -1,0 +1,37 @@
+component:
+  # Page header component, including primary navigation
+  header:
+    background:
+      color:
+        value: '{color.gray.800.value}'
+        comment: 'Header background color.'
+    nav:
+      text:
+        color:
+          value: '{color.gray.000.value}'
+        hover:
+          color:
+            value: '{color.primary.400.value}'
+      menulist:
+        text:
+          color:
+            themed:
+              light:
+                value: '{component.text.color.themed.light.value}'
+              dark:
+                value: '{color.gray.000.value}'
+        background:
+          color:
+            themed:
+              light:
+                value: '{color.gray.000.value}'
+              dark:
+                value: '{color.primary.600.value}'
+        selected:
+          background:
+            color:
+              themed:
+                light:
+                  value: '{color.primary.600.value}'
+                dark:
+                  value: '{color.primary.700.value}'

--- a/src/component/page.yaml
+++ b/src/component/page.yaml
@@ -1,0 +1,12 @@
+component:
+  # Page, for the main content
+  page:
+    background:
+      color:
+        themed:
+          light:
+            value: '{color.gray.000.value}'
+            comment: 'Page background color'
+          dark:
+            value: '{color.gray.800.value}'
+            comment: 'Page background color in dark theme'

--- a/src/component/servicecard.yaml
+++ b/src/component/servicecard.yaml
@@ -1,0 +1,16 @@
+component:
+  serviceCard:
+    background:
+      color:
+        themed:
+          light:
+            value: '{color.gray.000.value}'
+          dark:
+            value: '{color.gray.800.value}'
+    text:
+      color:
+        themed:
+          light:
+            value: '{component.text.color.themed.light.value}'
+          dark:
+            value: '{component.text.color.themed.dark.value}'

--- a/src/component/text.yaml
+++ b/src/component/text.yaml
@@ -9,3 +9,32 @@ component:
         dark:
           value: '{color.gray.100.value}'
           comment: 'Body text color in dark theme'
+    reverse:
+      color:
+        value: '{color.gray.100.value}'
+        comment: 'Body text color in reversed (light on dark) contexts.'
+    link:
+      color:
+        themed:
+          light:
+            value: '#146685' # darker than blue-500
+          dark:
+            value: '{color.blue.500.value}'
+      hover:
+        color:
+          themed:
+            light:
+              value: '{color.blue.500.value}'
+            dark:
+              value: '{component.text.link.color.themed.light.value}'
+      reverse:
+        color:
+          value: '{component.text.link.color.themed.dark.value}'
+          comment: 'Link color in reversed (light on dark) contexts.'
+    headline:
+      color:
+        themed:
+          light:
+            value: '{color.primary.600.value}'
+          dark:
+            value: '{color.primary.600.value}'


### PR DESCRIPTION
Initial design tokens from components originating in the Squareone application (https://github.com/lsst-sqre/rsp-squareone). See https://github.com/lsst-sqre/rsp-squareone/pull/5